### PR TITLE
Convert Tufuwu/test2 to GitHub Actions

### DIFF
--- a/.github/workflows/test2.yml
+++ b/.github/workflows/test2.yml
@@ -1,0 +1,42 @@
+name: Tufuwu/test2
+on:
+  push:
+    branches:
+    - "**/*"
+  pull_request:
+concurrency:
+#   # This item has no matching transformer
+#   maximum_number_of_builds: 0
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - uses: actions/setup-python@v5.0.0
+      with:
+        python-version: "${{ matrix.python }}"
+#     # 'sudo' was not transformed because there is no suitable equivalent in GitHub Actions
+    - run: pip install -r requirements-dev.txt
+    - run: make flake
+    - run: make test
+    - run: codecov
+      if: "${{ success() }}"
+#     # This item has no matching transformer
+#     - email: false
+    - uses: distributhor/workflow-webhook@v3.0.5
+      if: "${{ always() }}"
+      env:
+        webhook_url: "${{ secrets.WEBHOOK_URL }}"
+        webhook_secret: "${{ secrets.WEBHOOK_SECRET }}"
+    strategy:
+      matrix:
+        python:
+        - '3.5'
+        - '3.6'
+    services:
+      mongodb:
+        image: mongo
+      redis:
+        image: redis
+        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5


### PR DESCRIPTION
Pipeline migrated from [Travis CI](https://travis-ci.com/Tufuwu/test2) :tada:

## Manual steps

Perform the following steps to complete the migration:

### Tufuwu/test2
- [ ] Ensure secret is available: `${{ secrets.WEBHOOK_SECRET }}`
- [ ] Ensure secret is available: `${{ secrets.WEBHOOK_URL }}`