### PR TITLE
Convert Tufuwu/test2 to GitHub Actions

### DIFF
--- a/.github/workflows/test2.yml
+++ b/.github/workflows/test2.yml
@@ -1,0 +1,46 @@
+name: Tufuwu/test2
+on:
+  push:
+    branches:
+    - "**/*"
+  pull_request:
+concurrency:
+#   # This item has no matching transformer
+#   maximum_number_of_builds: 0
+env:
+  ANSIBLE_ROLE: dokku_bot.ansible_dokku
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - run: pip install -r requirements.txt
+    - run: ansible --version
+    - run: cd ../
+    - run: mv ansible-dokku $ANSIBLE_ROLE
+    - run: cd $ANSIBLE_ROLE
+    - run: |
+        make generate; if [[ $(git diff) ]]; then
+          echo "Please run `make generate`";
+          git status --short;
+          git diff;
+          exit 1;
+        fi
+    - run: molecule test
+    - uses: distributhor/workflow-webhook@v3.0.5
+      env:
+        webhook_url: https://galaxy.ansible.com/api/v1/notifications/
+        webhook_secret: "${{ secrets.WEBHOOK_SECRET }}"
+    strategy:
+      matrix:
+        MOLECULE_DISTRO:
+        - ubuntu1804
+        - ubuntu1604
+        - debian10
+        - debian9
+    services:
+#       # This item has no matching transformer
+#       docker:
+    env:
+      MOLECULE_DISTRO: "${{ matrix.MOLECULE_DISTRO }}"


### PR DESCRIPTION
Pipeline migrated from [Travis CI](https://travis-ci.com/Tufuwu/test2) :tada:

## Manual steps

Perform the following steps to complete the migration:

### Tufuwu/test2
- [ ] Ensure secret is available: `${{ secrets.WEBHOOK_SECRET }}`