### PR TITLE
Convert Tufuwu/test2 to GitHub Actions

### DIFF
--- a/.github/workflows/test2.yml
+++ b/.github/workflows/test2.yml
@@ -1,0 +1,68 @@
+name: Tufuwu/test2
+on:
+  push:
+    branches:
+    - "**/*"
+  pull_request:
+concurrency:
+#   # This item has no matching transformer
+#   maximum_number_of_builds: 0
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+#     # 'sudo' was not transformed because there is no suitable equivalent in GitHub Actions
+    - run: docker build -t ultisnips:${TAG} --build-arg PYTHON_IMAGE=${PYTHON_IMAGE} --build-arg VIM_VERSION=${VIM_VERSION} .
+    - run: docker run -it ultisnips:${TAG} docker/run_tests.sh
+    - uses: distributhor/workflow-webhook@v3.0.5
+      env:
+        webhook_url: https://webhooks.gitter.im/e/558acac434012ba838cd
+        webhook_secret: "${{ secrets.WEBHOOK_SECRET }}"
+    strategy:
+      matrix:
+        include:
+        - VIM_VERSION: '7.4'
+          PYTHON_IMAGE: 3.5-stretch
+          TAG: vim_74_py35
+        - VIM_VERSION: '8.0'
+          PYTHON_IMAGE: 3.5-stretch
+          TAG: vim_80_py35
+        - VIM_VERSION: '8.1'
+          PYTHON_IMAGE: 3.5-stretch
+          TAG: vim_81_py35
+        - VIM_VERSION: git
+          PYTHON_IMAGE: 3.5-stretch
+          TAG: vim_git_py35
+        - VIM_VERSION: '7.4'
+          PYTHON_IMAGE: 3.6-stretch
+          TAG: vim_74_py36
+        - VIM_VERSION: '8.0'
+          PYTHON_IMAGE: 3.6-stretch
+          TAG: vim_80_py36
+        - VIM_VERSION: '8.1'
+          PYTHON_IMAGE: 3.6-stretch
+          TAG: vim_81_py36
+        - VIM_VERSION: git
+          PYTHON_IMAGE: 3.6-stretch
+          TAG: vim_git_py36
+        - VIM_VERSION: '8.1'
+          PYTHON_IMAGE: 3.7-stretch
+          TAG: vim_81_py37
+        - VIM_VERSION: git
+          PYTHON_IMAGE: 3.7-stretch
+          TAG: vim_git_py37
+        - VIM_VERSION: '8.1'
+          PYTHON_IMAGE: 3.8-buster
+          TAG: vim_81_py38
+        - VIM_VERSION: git
+          PYTHON_IMAGE: 3.8-buster
+          TAG: vim_git_py38
+    services:
+#       # This item has no matching transformer
+#       docker:
+    env:
+      VIM_VERSION: "${{ matrix.VIM_VERSION }}"
+      PYTHON_IMAGE: "${{ matrix.PYTHON_IMAGE }}"
+      TAG: "${{ matrix.TAG }}"


### PR DESCRIPTION
Pipeline migrated from [Travis CI](https://travis-ci.com/Tufuwu/test2) :tada:

## Manual steps

Perform the following steps to complete the migration:

### Tufuwu/test2
- [ ] Ensure secret is available: `${{ secrets.WEBHOOK_SECRET }}`