### PR TITLE
Convert Tufuwu/test2 to GitHub Actions

### DIFF
--- a/.github/workflows/test2.yml
+++ b/.github/workflows/test2.yml
@@ -1,0 +1,35 @@
+name: Tufuwu/test2
+on:
+  push:
+    branches:
+    - "**/*"
+  pull_request:
+concurrency:
+#   # This item has no matching transformer
+#   maximum_number_of_builds: 0
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - uses: actions/setup-python@v5.0.0
+      with:
+        python-version: "${{ matrix.python }}"
+    - run: pip install flake8
+    - run: pip install -r requirements.txt
+    - run: flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+    - run: make test
+    - uses: distributhor/workflow-webhook@v3.0.5
+      env:
+        webhook_url: https://webhooks.gitter.im/e/43cd57826e88ed8f2152
+        webhook_secret: "${{ secrets.WEBHOOK_SECRET }}"
+    strategy:
+      matrix:
+        python:
+        - '3.4'
+        - '3.5'
+        - '3.6'
+        - '3.7'
+        - '3.8'
+        - pypy3


### PR DESCRIPTION
Pipeline migrated from [Travis CI](https://travis-ci.com/Tufuwu/test2) :tada:

## Manual steps

Perform the following steps to complete the migration:

### Tufuwu/test2
- [ ] Ensure secret is available: `${{ secrets.WEBHOOK_SECRET }}`