### PR TITLE
Convert Tufuwu/test2 to GitHub Actions

### DIFF
--- a/.github/workflows/test2.yml
+++ b/.github/workflows/test2.yml
@@ -1,0 +1,95 @@
+name: Tufuwu/test2
+on:
+  push:
+    branches:
+    - "**/*"
+    - master
+  pull_request:
+concurrency:
+#   # This item has no matching transformer
+#   maximum_number_of_builds: 0
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - uses: actions/setup-python@v5.0.0
+      with:
+        python-version: "${{ matrix.python }}"
+    - run: pip install -r requirements/requirements-dev.txt
+    - run: pip install --upgrade numpy>=1.16
+    - run: pip install --upgrade attrs>=19.2.0
+    - run: pip install --upgrade pytest>=4.6
+    - run: python setup.py $SETUP_CMD
+    strategy:
+      matrix:
+        python:
+        - 3.7
+        - 3.6
+        - 3.8
+#       # 'allow_failures' transformations are currently unsupported.
+  test_2:
+    runs-on: ubuntu-latest
+    env:
+      SETUP_CMD: "'install'"
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - uses: actions/setup-python@v5.0.0
+      with:
+        python-version: 3.7
+    - run: pip install -r requirements/requirements-dev.txt
+    - run: pip install --upgrade numpy>=1.16
+    - run: pip install --upgrade attrs>=19.2.0
+    - run: pip install --upgrade pytest>=4.6
+    - run: python setup.py $SETUP_CMD
+  test_3:
+    runs-on: ubuntu-latest
+    env:
+      SETUP_CMD: "'test"
+      "--coverage'": "${{ secrets.__COVERAGE }}"
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - uses: actions/setup-python@v5.0.0
+      with:
+        python-version: 3.7
+    - run: pip install -r requirements/requirements-dev.txt
+    - run: pip install --upgrade numpy>=1.16
+    - run: pip install --upgrade attrs>=19.2.0
+    - run: pip install --upgrade pytest>=4.6
+    - run: python setup.py $SETUP_CMD
+    - run: coveralls --rcfile='fiasco/tests/coveragerc'
+      if: "${{ success() }}"
+  test_4:
+    runs-on: ubuntu-latest
+    env:
+      SETUP_CMD: "'test"
+      "--pep8'": "${{ secrets.__PEP8 }}"
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - uses: actions/setup-python@v5.0.0
+      with:
+        python-version: 3.7
+    - run: pip install -r requirements/requirements-dev.txt
+    - run: pip install --upgrade numpy>=1.16
+    - run: pip install --upgrade attrs>=19.2.0
+    - run: pip install --upgrade pytest>=4.6
+    - run: python setup.py $SETUP_CMD
+  test_5:
+    runs-on: ubuntu-latest
+    env:
+      SETUP_CMD: "'build_docs'"
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - uses: actions/setup-python@v5.0.0
+      with:
+        python-version: 3.7
+    - run: pip install -r requirements/requirements-dev.txt
+    - run: pip install --upgrade numpy>=1.16
+    - run: pip install --upgrade attrs>=19.2.0
+    - run: pip install --upgrade pytest>=4.6
+    - run: python setup.py $SETUP_CMD


### PR DESCRIPTION
Pipeline migrated from [Travis CI](https://travis-ci.com/Tufuwu/test2) :tada:

## Manual steps

Perform the following steps to complete the migration:

### Tufuwu/test2
- [ ] Ensure secret is available: `${{ secrets.__COVERAGE }}`
- [ ] Ensure secret is available: `${{ secrets.__PEP8 }}`