### PR TITLE
Convert Tufuwu/test2 to GitHub Actions

### DIFF
--- a/.github/workflows/test2.yml
+++ b/.github/workflows/test2.yml
@@ -1,0 +1,49 @@
+name: Tufuwu/test2
+on:
+  push:
+    branches:
+    - "**/*"
+  pull_request:
+concurrency:
+#   # This item has no matching transformer
+#   maximum_number_of_builds: 0
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - uses: actions/setup-python@v5.0.0
+      with:
+        python-version: "${{ matrix.python }}"
+    - run: python setup.py sdist bdist_wheel
+    - run: pip install dist/*.whl
+    - run: pip install twine flake8 pytest
+    - run: twine check dist/*
+    - run: flake8
+    - run: pytest
+    strategy:
+      matrix:
+        python:
+        - '3.8'
+        - '3.7'
+        - '3.6'
+        - '3.5'
+        - '2.7'
+  Upload_release_to_PyPI:
+    needs:
+    - test
+    runs-on: ubuntu-latest
+    env:
+      TWINE_USERNAME: pyqtconsole
+    if: ${{ github.ref }}
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - uses: actions/setup-python@v5.0.0
+      with:
+        python-version: '3.8'
+    - run: python setup.py sdist bdist_wheel
+    - run: pip install dist/*.whl
+    - run: pip install twine flake8 pytest
+    - run: twine upload dist/*


### PR DESCRIPTION
Pipeline migrated from [Travis CI](https://travis-ci.com/Tufuwu/test2) :tada:

## Manual steps

Perform the following steps to complete the migration:

### Tufuwu/test2
- [ ] Ensure: Please add encrypted env variables as secrets in GitHub Actions