### PR TITLE
Convert Tufuwu/test2 to GitHub Actions

### DIFF
--- a/.github/workflows/test2.yml
+++ b/.github/workflows/test2.yml
@@ -1,0 +1,32 @@
+name: Tufuwu/test2
+on:
+  push:
+    branches:
+    - "**/*"
+  pull_request:
+concurrency:
+#   # This item has no matching transformer
+#   maximum_number_of_builds: 0
+jobs:
+  test:
+    runs-on: # this agent type is not supported: [[{"dist"=>"noble"}]]
+             ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - uses: actions/setup-python@v5.0.0
+      with:
+        python-version: "${{ matrix.python }}"
+    - run: pip install .
+    - run: pip install scipy
+    - run: pytest
+    - uses: rtCamp/action-slack-notify@v2.2.1
+      env:
+        SLACK_WEBHOOK: "${{ secrets.SLACK_WEBHOOK }}"
+        SLACK_CHANNEL: bayeso:FWBoHH9TMqjKUJWkZxCaTNVE
+    strategy:
+      matrix:
+        python:
+        - '3.8'
+        - '3.9'
+        - '3.10'


### PR DESCRIPTION
Pipeline migrated from [Travis CI](https://travis-ci.com/Tufuwu/test2) :tada:

## Manual steps

Perform the following steps to complete the migration:

### Tufuwu/test2
- [ ] Ensure secret is available: `${{ secrets.SLACK_WEBHOOK }}`